### PR TITLE
Add PHP 8.4 support and require PHP 8.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.3', '8.4']
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/security-core": "^6.4|^7.0"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "symfony/framework-bundle": "^6.4|^7.0",
         "doctrine/dbal": "^2.10|^3.0",
         "symfony/serializer": "^6.4|^7.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,7 +13,6 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('log');
 
-        /** @phpstan-ignore class.notFound (PHPStan issue with Symfony Config generic types) */
         $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('log_filters')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('log');
 
+        /** @phpstan-ignore class.notFound (PHPStan issue with Symfony Config generic types) */
         $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('log_filters')

--- a/src/Exception/UnsupportObjectException.php
+++ b/src/Exception/UnsupportObjectException.php
@@ -6,7 +6,7 @@ namespace AssoConnect\LogBundle\Exception;
 
 class UnsupportObjectException extends \DomainException
 {
-    public function __construct($object, $code = 0, \Throwable $previous = null)
+    public function __construct($object, $code = 0, ?\Throwable $previous = null)
     {
         $message = sprintf('Unhandled object of class %s', $object::class);
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement to 8.3
- Add PHP 8.4 to CI test matrix

## Changes
- Update composer.json to require PHP ^8.3
- Update GitHub Actions workflow to test on PHP 8.3 and 8.4

## Related
Part of organization-wide upgrade to standardize on PHP 8.3+ across all packages.

## Test plan
- [ ] CI tests pass on PHP 8.3
- [ ] CI tests pass on PHP 8.4