### PR TITLE
Upgrade assoconnect/php-quality-config to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,18 +31,18 @@
         }
     },
     "require-dev": {
-        "symfony/yaml": "^6.4|^7.0",
-        "symfony/validator": "^6.4|^7.0",
-        "phpstan/phpstan-symfony": "^1.0",
+        "symfony/yaml": "^7.0",
+        "symfony/validator": "^7.0",
+        "phpstan/phpstan-symfony": "^2",
         "assoconnect/php-quality-config": "^2",
-        "symfony/security-core": "^6.4|^7.0"
+        "symfony/security-core": "^7.0"
     },
     "require": {
         "php": "^8.3",
-        "symfony/framework-bundle": "^6.4|^7.0",
+        "symfony/framework-bundle": "^7.0",
         "doctrine/dbal": "^2.10|^3.0",
-        "symfony/serializer": "^6.4|^7.0",
-        "symfony/property-access": "^6.4|^7.0",
+        "symfony/serializer": "^7.0",
+        "symfony/property-access": "^7.0",
         "doctrine/doctrine-bundle": "^2.11",
         "doctrine/orm": "^2.9",
         "moneyphp/money": "^3.2|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/yaml": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0",
         "phpstan/phpstan-symfony": "^1.0",
-        "assoconnect/php-quality-config": "^1.16",
+        "assoconnect/php-quality-config": "^2",
         "symfony/security-core": "^6.4|^7.0"
     },
     "require": {

--- a/tests/Functional/App/TestKernel.php
+++ b/tests/Functional/App/TestKernel.php
@@ -14,11 +14,9 @@ class TestKernel extends Kernel
 {
     public function registerBundles(): iterable
     {
-        return [
-            new FrameworkBundle(),
-            new LogBundle(),
-            new DoctrineBundle(),
-        ];
+        yield new FrameworkBundle();
+        yield new LogBundle();
+        yield new DoctrineBundle();
     }
 
     public function getCacheDir(): string
@@ -29,11 +27,6 @@ class TestKernel extends Kernel
     public function getLogDir(): string
     {
         return $this->basePath() . 'logs';
-    }
-
-    public function getRootDir(): string
-    {
-        return __DIR__;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Upgrade assoconnect/php-quality-config from ^1.16 to ^2
- Dropping support for Symfony 6

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)