### PR TITLE
Require PHP 8.4 and add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4']
+        php-versions: ['8.4', '8.5']
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/security-core": "^7.0"
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "symfony/framework-bundle": "^7.0",
         "doctrine/dbal": "^2.10|^3.0",
         "symfony/serializer": "^7.0",


### PR DESCRIPTION
## Summary
- Bump minimum PHP requirement from `^8.3` to `^8.4` in `composer.json`
- Replace PHP 8.3 with PHP 8.5 in the CI test matrix (keeping PHP 8.4)

## Test plan
- [ ] CI passes on PHP 8.4 and 8.5 with lowest/highest dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)