### PR TITLE
fix: replace deprecated getEntityManager() with getObjectManager()

### DIFF
--- a/src/Factory/LogDataFactory.php
+++ b/src/Factory/LogDataFactory.php
@@ -26,7 +26,6 @@ class LogDataFactory
     public function createFromEvent(OnFlushEventArgs $eventArgs): iterable
     {
         $em = $eventArgs->getObjectManager();
-        assert($em instanceof EntityManagerInterface);
         $unitOfWork = $em->getUnitOfWork();
 
         // Creation

--- a/src/Factory/LogDataFactory.php
+++ b/src/Factory/LogDataFactory.php
@@ -25,7 +25,8 @@ class LogDataFactory
     /** @return LogData[] */
     public function createFromEvent(OnFlushEventArgs $eventArgs): iterable
     {
-        $em = $eventArgs->getEntityManager();
+        $em = $eventArgs->getObjectManager();
+        assert($em instanceof EntityManagerInterface);
         $unitOfWork = $em->getUnitOfWork();
 
         // Creation

--- a/src/Subscriber/LoggerSubscriber.php
+++ b/src/Subscriber/LoggerSubscriber.php
@@ -9,6 +9,7 @@ use AssoConnect\LogBundle\Factory\LogFactoryInterface;
 use AssoConnect\LogBundle\Factory\RequestContextAwareLogFactoryInterface;
 use AssoConnect\LogBundle\Factory\SecurityContextAwareLogFactoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
 
@@ -28,7 +29,8 @@ class LoggerSubscriber
 
     public function onFlush(OnFlushEventArgs $eventArgs): void
     {
-        $em = $eventArgs->getEntityManager();
+        $em = $eventArgs->getObjectManager();
+        assert($em instanceof EntityManagerInterface);
         $unitOfWork = $em->getUnitOfWork();
         $cmf = $em->getMetadataFactory();
         $requestTrace = $this->getRequestTrace();

--- a/src/Subscriber/LoggerSubscriber.php
+++ b/src/Subscriber/LoggerSubscriber.php
@@ -9,7 +9,6 @@ use AssoConnect\LogBundle\Factory\LogFactoryInterface;
 use AssoConnect\LogBundle\Factory\RequestContextAwareLogFactoryInterface;
 use AssoConnect\LogBundle\Factory\SecurityContextAwareLogFactoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
 
@@ -30,7 +29,6 @@ class LoggerSubscriber
     public function onFlush(OnFlushEventArgs $eventArgs): void
     {
         $em = $eventArgs->getObjectManager();
-        assert($em instanceof EntityManagerInterface);
         $unitOfWork = $em->getUnitOfWork();
         $cmf = $em->getMetadataFactory();
         $requestTrace = $this->getRequestTrace();


### PR DESCRIPTION
Doctrine ORM 2.13 deprecated `OnFlushEventArgs::getEntityManager()` in favour of `getObjectManager()`. Added `assert($em instanceof EntityManagerInterface)` to retain type safety for UnitOfWork / MetadataFactory calls.

Refs IT9PE1-28431